### PR TITLE
[Generator] Fixed wp-config salts replacement

### DIFF
--- a/generator/app/templates/web/wp-config.php
+++ b/generator/app/templates/web/wp-config.php
@@ -16,7 +16,8 @@ require_once(dirname(__FILE__) . '/../bower_components/genesis-wordpress/src/Gen
   .replace(/define\('WP_DEBUG'.+\);/, "define('WP_DEBUG', WP_ENV === 'local');")
 
   // Replace salts
-  .replace(/(\/\*\*#@\+.+?\*\/\n).+?(\n\/\*\*#@-\*\/)/m, "$1" + props.salts + "$2")
+  .replace(/(\/\*\*#@\+(?:.|[\r\n])+?\*\/[\r\n]+)(?:.|[\r\n])+?([\r\n]+\/\*\*#@-\*\/)/m, '$1__GENERATED_SALTS_PLACEHOLDER__$2')
+  .split('__GENERATED_SALTS_PLACEHOLDER__').join(props.salts)
 
   // Limit to 5 post revisions
   .replace("/* That's all,", "define('WP_POST_REVISIONS', 5);\n\n/*That's all,")


### PR DESCRIPTION
Fixes:
- Regexp now properly handles carriage returns and/or newlines (since javascript doesn't match them with dots)
- Separate literal string replace (as `split(match).join(replace)`) since generated salts could contain "$" strings interpreted as backrefs

That second point works around a baffling javascript bug where `String.replace()` with a literal string match still interpolates special backrefs:

``` js
"foo bar baz".replace('bar', '$`')
# "foo foo  baz"
```
