### PR TITLE
Generator removing + replacing existing blocks in README and htaccess

### DIFF
--- a/generator/app/index.js
+++ b/generator/app/index.js
@@ -232,6 +232,10 @@ WordpressGenerator.prototype.writeProjectFiles = function() {
 
   try {
     this.readmeFile = this.readFileAsString(path.join(this.env.cwd, 'README.md'));
+    this.readmeFile = this.readmeFile
+      .replace(/^(?:\[[^\]]+\]){1,2}(?:\([^\)]+\))?[\r\n]+=+[\r\n]+> Powered by \[Genesis[^\r\n]+[\r\n]+/i, '')
+      .replace(/\[[^\]]+\]:\s*http[^\r\n]+[\r\n]+\[genesis-wordpress\]:\s*http[^\r\n]+[\r\n]*$/i, '')
+    ;
   } catch(e) {
     this.readmeFile = '';
   }
@@ -267,6 +271,7 @@ WordpressGenerator.prototype.writeWeb = function() {
 
   try {
     this.htaccessFile = this.readFileAsString(path.join(this.env.cwd, this.props.web, '.htaccess'));
+    this.htaccessFile = this.htaccessFile.replace(/# BEGIN Genesis WordPress(?:.|[\r\n]+)+?# END Genesis WordPress[\r\n]*/i, '');
   } catch(e) {
     this.htaccessFile = '';
   }

--- a/generator/app/templates/README.md
+++ b/generator/app/templates/README.md
@@ -1,7 +1,7 @@
 [<%= props.name %>][<%= props.domain %>]
 <%= new Array(props.name.length + props.domain.length + 5).join('=') %>
 
-> Powered by [Genesis WordPress][genesis-wordpress]
+> Powered by [Genesis WordPress <%= props.genesis %>][genesis-wordpress]
 
 <%= readmeFile %>
 [<%= props.domain %>]: http://www.<%= props.domain %>/


### PR DESCRIPTION
Previously, running the generator against an existing genesis project would [add duplicate template blocks](https://gist.github.com/EvanK/831fb6cc341ab80234a8) to `README.md` and `.web/htaccess` without removing what was already there.

This PR should [instead replace said blocks](https://gist.github.com/EvanK/66be3ed0f6b1a4df91cf), and in addition add the current generator version from `bower.json`, for quick reference.
