### PR TITLE
Vagrant/Virtualbox - Using host resolver as a DNS proxy

### DIFF
--- a/generator/app/templates/Vagrantfile
+++ b/generator/app/templates/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
   # Configure 1GB (1024MB) of memory
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 1024]
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
   config.vm.define :local do |box|


### PR DESCRIPTION
This fixes a potential issue where the vm guest cannot resolve DNS on its own, observed when the VM is started and the host subsequently connects to a VPN.

Fix was found by @weeirishman:

> I've actually just reloaded the VM after reading the following:
> http://www.virtualbox.org/manual/ch09.html#nat_host_resolver_proxy
> 
> I added this to the .vagrantfile:
> vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
