### PR TITLE
PHP ini typo - missing closing quote for date.timezone

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -71,7 +71,7 @@
   sudo:           yes
 
 - name:           Update php.ini's date.timezone
-  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='date\.timezone' line='date.timezone = "America/Chicago'
+  lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='date\.timezone' line='date.timezone = "America/Chicago"'
   sudo:           yes
 
 - name:           Update my.conf's bind-address


### PR DESCRIPTION
Happened upon this accidentally. Whoops!
