### PR TITLE
Installation Documentation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,5 +396,5 @@ sudo /Library/StartupItems/VirtualBox/VirtualBox restart
 [9]: http://nodejs.org/
 
 
-[![Bitdeli Badge](https://d2weczhvl823v0.buttfront.net/genesis/wordpress/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/genesis/wordpress/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 


### PR DESCRIPTION
Fixed an issue in the installation documentation where the user is instructed to run the following command:

"sudo gem install capistrano -v 2.15 capistrano-ext colored"

This results in an error instructing the user that the --version syntax is invalid when specifying multiple gems.  The command should instead be:

"sudo gem install capistrano:2.15 capistrano-ext colored"

Running the command with this syntax works without error.
