### PR TITLE
.editorconfig Changes

### DIFF
--- a/generator/app/templates/editorconfig
+++ b/generator/app/templates/editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.html, *.php]
+indent_size = 4


### PR DESCRIPTION
Opening up a conversation about the .editorconfig defaults.

Points from EC:
- Should .editorconfig encourage the WordPress settings, or encourage the PHP PSR ("proper") settings?
- Whichever one is chosen, when WordPress is downloaded by the generator, the files should be formatted appropriately to avoid any future "giant commit that's all whitespace changes"
- .editorconfig requires plugins to work

Other points
- Currently defaults to 2 spaces for all files requiring each new file to be changed manually.
- Should we even be setting defaults for WP files (including the themes)? Would it be better to limit the .editorconfig to the Genesis core?
