### PR TITLE
Added capability for domain aliases

### DIFF
--- a/generator/app/index.js
+++ b/generator/app/index.js
@@ -66,12 +66,26 @@ WordpressGenerator.prototype.promptForName = function() {
 };
 
 WordpressGenerator.prototype.promptForDomain = function() {
+  var existing = function() {
+    try {
+      var groupVars = this.readFileAsString(path.join(this.env.cwd, 'provisioning', 'group_vars', 'webservers'));
+
+      var matches = groupVars.match(/^domain:[\t ]*(\S+)\s/m);
+
+      if (matches) {
+        return matches[1];
+      }
+    } catch(e) {};
+  }.bind(this);
+
   this.prompts.push({
     required: true,
     type:     'text',
     name:     'domain',
     message:  'Domain name (e.g. mysite.com)',
-    default:  path.basename(this.env.cwd).toLowerCase(),
+    default:  function() {
+      return existing() || path.basename(this.env.cwd).toLowerCase();
+    }.bind(this),
     validate: function(input) {
       if (/^[\w-]+\.\w+(?:\.\w{2,3})?$/.test(input)) {
         return true;
@@ -92,7 +106,7 @@ WordpressGenerator.prototype.promptForAliases = function() {
       var matches = groupVars.match(/^aliases:(?:\s+-[ ]+\S+)+/m);
 
       if (matches) {
-        aliases = matches[0].split(/\s+-[ ]+/);
+        var aliases = matches[0].split(/\s+-[ ]+/);
         aliases.shift();
 
         return aliases.join(' ');

--- a/generator/app/index.js
+++ b/generator/app/index.js
@@ -84,6 +84,42 @@ WordpressGenerator.prototype.promptForDomain = function() {
   });
 };
 
+WordpressGenerator.prototype.promptForAliases = function() {
+  var existing = function() {
+    try {
+      var groupVars = this.readFileAsString(path.join(this.env.cwd, 'provisioning', 'group_vars', 'webservers'));
+
+      var matches = groupVars.match(/^aliases:(?:\s+-[ ]+\S+)+/m);
+
+      if (matches) {
+        aliases = matches[0].split(/\s+-[ ]+/);
+        aliases.shift();
+
+        return aliases.join(' ');
+      }
+    } catch(e) {};
+  }.bind(this);
+
+  this.prompts.push({
+    required: true,
+    type:     'text',
+    name:     'aliases',
+    message:  'Domain aliases, space delimited (e.g. mysite.net mysite.org)',
+    default:  function() {
+      return existing() || '';
+    }.bind(this),
+    validate: function(input) {
+      if (/^([\w-]+\.\w+(?:\.\w{2,3})?(?:[ ]+)?)+$/.test(input)) {
+        return true;
+      } else if (!input) {
+        return true;
+      }
+
+      return chalk.yellow(input) + ' does not match the example';
+    }
+  });
+};
+
 WordpressGenerator.prototype.promptForGenesis = function() {
   this.prompts.push({
     type:     'text',

--- a/generator/app/templates/Vagrantfile
+++ b/generator/app/templates/Vagrantfile
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.define :local do |box|
     box.vm.hostname = "local.<%= props.domain %>"
-
+<% if (props.aliases) { %>    box.hostmanager.aliases = %w(<%= props.aliases.split(/\s+/).map(function (alias) { return 'local.' + alias; }).join(' ') %>)
+<% } %>
     # Static IP for testing.
     box.vm.network :private_network, ip: "<%= props.ip %>"
     box.vm.network :forwarded_port, guest: 22, host: <%= props.ip.split('.').join('').split('0').join('').slice(-4) %>, auto_correct: true

--- a/generator/app/templates/provisioning/group_vars/webservers
+++ b/generator/app/templates/provisioning/group_vars/webservers
@@ -1,5 +1,7 @@
 ---
 domain:       <%= props.domain %>
+aliases:<% if (props.aliases) { props.aliases.split(/\s+/).forEach(function (alias) { %>
+  - <%= alias %><% }); } else { %>      []<% } %>
 mysql:
   name:       <%= props.DB_NAME %>
   user:       <%= props.DB_USER %>

--- a/generator/app/templates/web/htaccess
+++ b/generator/app/templates/web/htaccess
@@ -126,7 +126,14 @@ SetEnvIf Host ^local\. allow_wp_install
   # Rules to help reduce spam
   RewriteCond %{REQUEST_METHOD} POST
   RewriteCond %{REQUEST_URI} ^(.*)wp-comments-post\.php*
-  RewriteCond %{HTTP_REFERER} !^(.*)<%= props.domain %>.*
+  RewriteCond %{HTTP_REFERER} !^(.*)<%
+if (props.aliases) {
+  %>(<%= props.domain %>|<%
+  %><%= props.aliases.split(/\s+/).join('|') %>)<%
+} else {
+  %><%= props.domain %><%
+}
+%>.*
   RewriteCond %{HTTP_REFERER} !^http://jetpack\.wordpress\.com/jetpack-comment/ [OR]
   RewriteCond %{HTTP_USER_AGENT} ^$
   RewriteRule ^(.*)$ - [F]

--- a/provisioning/roles/wordpress/templates/vhosts/000-local
+++ b/provisioning/roles/wordpress/templates/vhosts/000-local
@@ -3,6 +3,10 @@
 
     ServerName local.{{ domain }}
 
+{% for alias in aliases %}
+    ServerAlias local.{{ alias }}
+{% endfor %}
+
     DocumentRoot /vagrant/web
     <Directory />
         Options FollowSymLinks

--- a/provisioning/roles/wordpress/templates/vhosts/001-staging
+++ b/provisioning/roles/wordpress/templates/vhosts/001-staging
@@ -3,6 +3,10 @@
 
     ServerName staging.{{ domain }}
 
+{% for alias in aliases %}
+    ServerAlias staging.{{ alias }}
+{% endfor %}
+
     DocumentRoot /var/www/{{ domain }}/master/current/web
     <Directory />
         Options FollowSymLinks

--- a/provisioning/roles/wordpress/templates/vhosts/002-branch
+++ b/provisioning/roles/wordpress/templates/vhosts/002-branch
@@ -4,6 +4,10 @@
     ServerName branch.staging.{{ domain }}
     ServerAlias *.staging.{{ domain }}
 
+{% for alias in aliases %}
+    ServerAlias branch.staging.{{ alias }} *.staging.{{ alias }}
+{% endfor %}
+
     VirtualDocumentRoot /var/www/{{ domain }}/%1/current/web
     <Directory />
         Options FollowSymLinks

--- a/provisioning/roles/wordpress/templates/vhosts/003-production
+++ b/provisioning/roles/wordpress/templates/vhosts/003-production
@@ -7,6 +7,10 @@
     ServerAlias www.{{ domain }}
     ServerAlias *.{{ domain }}
 
+{% for alias in aliases %}
+    ServerAlias {{ alias }} production.{{ alias }} www.{{ alias }} *.{{ alias }}
+{% endfor %}
+
     DocumentRoot /var/www/{{ domain }}/master/current/web
     <Directory />
         Options FollowSymLinks


### PR DESCRIPTION
The purpose of these is _not_ to replace the canonical domain, but to allow the genesis site in question to serve requests for any number of _additional_ domains.
* stored in ansible's group_vars
* added as hostmanager aliases in Vagrantfile
* properly handled in htaccess rewrite conditions for spam reduction
* added as ServerAlias in apache vhosts

As an example, we have a site with the domain `thisproject.mycompany.com`, maintained for a third party, `othercompany.org`. For all intents and purposes, we host it as (and test and send staging traffic as) `staging.thisproject.mycompany.com` and `production.thisproject.mycompany.com`.

Once it goes live, however, we _also_ want it to serve traffic under a subdomain of said third party, `thisproject.othercompany.org`. Domain aliases allow this to happen.

Note that I have _no clue_ how this may affect wordpress' functionality as far as:
* storing absolute urls in the database
* generating urls under the current hostname vs the domain wordpress is configured for
* creating content/comments from aliased domains

Ping @ericrasch 