### PR TITLE
Monkeypatched SSL

### DIFF
--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -5,3 +5,4 @@
     - common
     - wordpress
     - varnish
+    - pound

--- a/provisioning/roles/pound/handlers/main.yml
+++ b/provisioning/roles/pound/handlers/main.yml
@@ -2,3 +2,7 @@
 - name:     restart pound
   service:  name=pound state=restarted
   sudo:     true
+
+- name:     stop pound
+  service:  name=pound state=stopped
+  sudo:     true

--- a/provisioning/roles/pound/handlers/main.yml
+++ b/provisioning/roles/pound/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name:     restart pound
+  service:  name=pound state=restarted
+  sudo:     true

--- a/provisioning/roles/pound/tasks/disable.yml
+++ b/provisioning/roles/pound/tasks/disable.yml
@@ -1,0 +1,6 @@
+---
+- name:          Disable pound
+  lineinfile:    regexp='^startup=1' line='startup=0' dest=/etc/default/pound
+  notify:        stop pound
+  ignore_errors: yes
+  sudo:          yes

--- a/provisioning/roles/pound/tasks/install.yml
+++ b/provisioning/roles/pound/tasks/install.yml
@@ -1,0 +1,32 @@
+# https://launchpad.net/~unleashedtech/+archive/ubuntu/pound-2.7
+- name:       Register pound 2.7 ppa
+  apt_repository: repo='ppa:unleashedtech/pound-2.7'
+  sudo:       true
+
+- name:       Install pound packages
+  apt:        pkg={{item}} state=latest update_cache=yes
+  with_items:
+    - ssl-cert
+    - pound
+  sudo:       true
+  sudo_user:  root
+
+- name:       Copy pound configuration file
+  template:   src=pound.cfg dest=/etc/pound/pound.cfg mode=0644
+  notify:     restart pound
+  sudo:       true
+
+- name:       Copy SSL certificate
+  copy:       src={{ pound__cert_path }}/{{ pound__cert_name }} dest=/etc/pound/genesis-{{ domain }}.pem mode=0644
+  notify:     restart pound
+  sudo:       true
+
+- name:       Enable pound
+  lineinfile: regexp='^startup=0' line='startup=1' dest=/etc/default/pound backup=yes
+  notify:     restart pound
+  sudo:       yes
+
+- name:       Configure HTTPS Forwarded Proto detection in Apache 2.2
+  copy:       content="SetEnvIf X-Forwarded-Proto ^https$ HTTPS=on\n" dest=/etc/apache2/conf.d/https-forwarded-proto.conf mode=0644
+  notify:     restart apache
+  sudo:       true

--- a/provisioning/roles/pound/tasks/main.yml
+++ b/provisioning/roles/pound/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name:          Find pem cert, if one exists (should include key)
+  local_action:  shell ls -1 {{ inventory_dir }}/files/ssl/*.pem
+  ignore_errors: yes
+  register:      pound__cert_exists
+
+- name:          Set cert filename and path
+  set_fact:
+    pound__cert_name: "{{ pound__cert_exists.stdout_lines[0] | basename }}"
+    pound__cert_path: "{{ pound__cert_exists.stdout_lines[0] | dirname }}"
+  when:          pound__cert_exists.stdout != ""
+
+- debug:         var=pound__cert_name
+- debug:         var=pound__cert_path
+
+- include:       install.yml
+  when:          pound__cert_exists.stdout != ""

--- a/provisioning/roles/pound/tasks/main.yml
+++ b/provisioning/roles/pound/tasks/main.yml
@@ -15,3 +15,6 @@
 
 - include:       install.yml
   when:          pound__cert_exists.stdout != ""
+
+- include:       disable.yml
+  when:          pound__cert_exists.stdout == ""

--- a/provisioning/roles/pound/templates/pound.cfg
+++ b/provisioning/roles/pound/templates/pound.cfg
@@ -1,0 +1,66 @@
+## Minimal sample pound.cfg
+##
+## see pound(8) for details
+
+
+######################################################################
+## global options:
+
+User    "www-data"
+Group   "www-data"
+#RootJail "/chroot/pound"
+
+## Logging: (goes to syslog by default)
+##  0 no logging
+##  1 normal
+##  2 extended
+##  3 Apache-style (common log format)
+LogLevel  1
+
+## check backend every X secs:
+Alive   60
+
+## use hardware-accelleration card supported by openssl(1):
+#SSLEngine  "<hw>"
+
+# poundctl control socket
+Control "/var/run/pound/poundctl.socket"
+
+
+######################################################################
+## listen, redirect and ... to:
+
+## redirect all requests on port 443 ("ListenHTTPS") to the local webserver (see "Service" below):
+ListenHTTPS
+  Address 0.0.0.0
+  Port    443
+
+  HeadRemove "X-Forwarded-Proto"
+  AddHeader  "X-Forwarded-Proto: https"
+
+{% if aliases %}
+{%   set all_domains = [ domain|replace('.','\\.') ] %}
+{%   for alias in aliases %}
+{%     set foo = all_domains.append( alias|replace('.','\\.') ) %}
+{%   endfor %}
+{%   set all_domains = '(' + all_domains|join('|') + ')' %}
+{% else %}
+{%   set all_domains = domain|replace('.','\\.') %}
+{% endif %}
+  Cert    "/etc/pound/genesis-{{ domain }}.pem"
+
+  Service
+    HeadRequire "Host: .*{{ all_domains }}.*"
+    BackEnd
+      Address 127.0.0.1
+      Port  80
+    End
+  End
+
+  ## https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers
+  Ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
+  SSLHonorCipherOrder 1
+  Disable SSLv2
+  Disable SSLv3
+
+End

--- a/src/Genesis.php
+++ b/src/Genesis.php
@@ -22,7 +22,7 @@ class Genesis
         update_option('upload_path', null);
 
         $old_url = site_url();
-        $new_url = ($_SERVER['SERVER_PORT'] === '443' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'];
+        $new_url = ($_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'];
 
         // Ensure internal WordPress functions map correctly to new url (but don't want to persist in the DB)
         add_filter('option_home',             function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });


### PR DESCRIPTION
This is a hasty backport of Evolution's pound role. For simplicity sake, it detects and uses **a single pem certificate** (in `./provisioning/files/ssl/`) across _all_ stages and for _all_ domains and aliases.

If no pem cert is found, pound installation and configuration is _skipped altogether_.

In the case that pound _was previously installed_ and then the cert is removed, pound will be stopped & disabled at the service level