### PR TITLE
Undefined index error with Vagrant v1.8.5

### DIFF
--- a/src/Genesis.php
+++ b/src/Genesis.php
@@ -22,7 +22,7 @@ class Genesis
         update_option('upload_path', null);
 
         $old_url = site_url();
-        $new_url = ($_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'];
+        $new_url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'];
 
         // Ensure internal WordPress functions map correctly to new url (but don't want to persist in the DB)
         add_filter('option_home',             function($value) use ($old_url, $new_url) { return str_replace($old_url, $new_url, $value); });


### PR DESCRIPTION
Upgraded Vagrant to `v1.8.5` and now I'm seeing `Notice: Undefined index: HTTPS in /vagrant/bower_components/genesis-wordpress/src/Genesis.php on line 25` on my local sites.