### PR TITLE
Disk space used but never freed from MySQL

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -127,8 +127,8 @@
   lineinfile:     dest=/etc/php5/apache2/php.ini backup=yes regexp='date\.timezone' line='date.timezone = "America/Chicago"'
   sudo:           yes
 
-- name:           Update my.conf's bind-address
-  lineinfile:     dest=/etc/mysql/my.cnf backup=yes regexp=^bind-address line='bind-address = 0.0.0.0'
+- name:           Tweak my.cnf
+  replace:        dest=/etc/mysql/my.cnf backup=yes regexp="^bind-address(.+)(\ninnodb_file_per_table.+)?" replace="bind-address = 0.0.0.0\ninnodb_file_per_table = 1"
   sudo:           yes
 
 - name:           Generate /etc/aliases


### PR DESCRIPTION
Evidently [a known issue](http://stackoverflow.com/questions/1270944/mysql-innodb-not-releasing-disk-space-after-deleting-data-rows-from-table#answer-1280625) for MySQL 5.5 and below, innodb uses a single file for assorted tables' storage, and consumes but _never releases_ disk space. This results in giant ib* files:

```
deploy@production:~$ sudo ls -alh /var/lib/mysql/
total 1.6G
drwx------  6 mysql mysql 4.0K Jun 10 16:49 .
drwxr-xr-x 41 root  root  4.0K Feb 23  2016 ..
-rw-r--r--  1 root  root     0 Aug 13  2015 debian-5.5.flag
-rw-rw----  1 mysql mysql 1.6G Aug 29 12:50 ibdata1
-rw-rw----  1 mysql mysql 5.0M Aug 29 12:50 ib_logfile0
-rw-rw----  1 mysql mysql 5.0M Aug 29 12:44 ib_logfile1
drwx------  2 mysql root  4.0K Aug 13  2015 mysql
-rw-rw----  1 root  root     6 Aug 13  2015 mysql_upgrade_info
drwx------  2 mysql mysql 4.0K Aug 26 15:21 wordpress
drwx------  2 mysql mysql 4.0K Aug 13  2015 performance_schema
drwx------  2 mysql root  4.0K Aug 13  2015 test
```