### PR TITLE
`when: stage == 'production'` logic fails in provision.yml

### DIFF
--- a/generator/app/templates/Vagrantfile
+++ b/generator/app/templates/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
 
     # Provision local.<%= props.domain %>
     box.vm.provision :shell do |shell|
-      shell.inline = "/vagrant/bin/provision"
+      shell.inline = "/vagrant/bin/provision -e stage=local"
     end
   end
 


### PR DESCRIPTION
Provisioning tasks fails when trying to evaluate `when: stage == 'production' in tasks

Terminal Output:
```sh
==> local: TASK: [Add New Relic key] *****************************************************
==> local: fatal: [127.0.0.1] => error while evaluating conditional: stage == 'production'
==> local:
==> local: FATAL: all hosts have already failed -- aborting
==> local:
==> local: PLAY RECAP ********************************************************************
==> local:            to retry, use: --limit @/root/provision.retry
==> local:
==> local: 127.0.0.1                  : ok=48   changed=41   unreachable=1    failed=0
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

There are several tasks running in `provision.yml` that only run `when: stage == 'production'` - [file here](https://github.com/HigherEducation/OnlineUniversities.com/blob/master/provisioning/provision.yml#L30-L73)

During local provisioning the 1st of those tasks fails (and vagrant never finishes setting up the box).